### PR TITLE
add: slot metrics

### DIFF
--- a/eevee/metrics.py
+++ b/eevee/metrics.py
@@ -1,20 +1,59 @@
-from typing import List
+from typing import Callable, List, Optional
 
+import numpy as np
 from sklearn.metrics import confusion_matrix
 
 from eevee.types import SlotLabel
 
 
-def slot_capture_rate() -> float:
-    ...
+def slot_capture_rate(slots_predicted: List[SlotLabel], expected_slot_value: str) -> float:
+    """
+    """
+
+    if isinstance(slots_predicted, list) and slots_predicted:
+        captured_count = slots_predicted.count(expected_slot_value)
+        return captured_count / len(slots_predicted)
+    else:
+        raise ValueError(f"Expected {slots_predicted = } to be a list of size greater than 0")
 
 
-def slot_retry_rate() -> float:
-    ...
+def slot_retry_rate(slot_turn_counts: List[Optional[int]], agg_fn: Callable = np.mean) -> float:
+    """
+    Slot retry rate refers to aggregating on the number of turns a slot requires.
+
+    Let `n` be the number of calls,
+    `slot_turn_counts` be number of turns required to handle the particular slot in each call.
+    `agg_fn` runs aggregation on `slot_turn_counts` and returns a float.
+    """
+
+    if isinstance(slot_turn_counts, list) and slot_turn_counts:
+        filtered_turn_counts = list(filter(None, slot_turn_counts))
+        return agg_fn(filtered_turn_counts)
+    else:
+        raise ValueError(f"Expected {slot_turn_counts =} to be a list of size greater than 0")
 
 
 def slot_mismatch_rate(y_true: List[SlotLabel], y_pred: List[SlotLabel]) -> float:
-    ...
+    """
+    As per the definition, slot mismatch rate captures
+    ratio of match on types-but-not-values with
+    match on types-but-not-values + match on types-and-values
+    """
+
+    type_and_value_matched = 0
+    type_matched_but_value_didnt = 0
+
+    for y_true_i, y_pred_i in zip(y_true, y_pred):
+
+        if type(y_true_i) == type(y_pred_i) and y_true_i is not None:
+            if y_true_i == y_pred_i:
+                type_and_value_matched += 1
+            else:
+                type_matched_but_value_didnt += 1
+
+    if type_matched_but_value_didnt + type_and_value_matched == 0:
+        return 0.0
+    return (type_matched_but_value_didnt) / (type_matched_but_value_didnt + type_and_value_matched)
 
 
 def top_k_slot_mismatch_rate(y_true: List[SlotLabel], y_pred: List[List[SlotLabel]], k=1) -> float:
@@ -44,4 +83,24 @@ def slot_fnr(y_true: List[SlotLabel], y_pred: List[SlotLabel]) -> float:
 
 
 def slot_fpr(y_true: List[SlotLabel], y_pred: List[SlotLabel]) -> float:
-    ...
+    """
+    False positive rate for slot prediction.
+
+    Slot type is handled outside this, so you will have to segregate the slot
+    labels based on types beforehand.
+
+    0 -> 1 is false positive, assuming 0 is negative label. 1 as positive label.
+    None -> {} is false positive under our situation.
+    """
+
+    _y_true = [0 if y is None else 1 for y in y_true]
+    _y_pred = [0 if y is None else 1 for y in y_pred]
+
+    mat = confusion_matrix(_y_true, _y_pred, labels=[0, 1])
+
+    tn, fp, *_ = mat.ravel()
+
+    if (fp + tn) == 0:
+        return 0
+    else:
+        return fp / (fp + tn)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,5 +1,32 @@
+import numpy as np
 import pytest
-from eevee.metrics import slot_fnr
+
+from eevee.metrics import slot_fnr, slot_fpr, slot_capture_rate, slot_mismatch_rate, slot_retry_rate
+
+
+@pytest.mark.parametrize("slots_predicted, expected_slot, scr", [
+    (["yes", "yes", "no", None], "no", 0.25),
+    (["yes", "yes", "no", None], "yes", 0.5),
+])
+def test_slot_scr(slots_predicted, expected_slot, scr):
+    assert slot_capture_rate(slots_predicted, expected_slot) == scr
+
+
+@pytest.mark.parametrize("slot_turn_counts, agg_fn, srr", [
+    ([1, 2, 3, 2, 1, 1, 4, 5, None, None], np.mean, 2.375),
+    ([1, 2, 3, 2, 1, 1, 4, 5, None, None], np.median, 2.0),
+])
+def test_slot_srr(slot_turn_counts, agg_fn, srr):
+    assert slot_retry_rate(slot_turn_counts, agg_fn) == srr
+
+
+@pytest.mark.parametrize("y_true, y_pred, smr", [
+    ([None, None, None, None], [None, None, None, None], 0),
+    ([1, 1, 1, 1, None], [1, 1, 1, 2, None], 0.25),
+])
+def test_slot_smr(y_true, y_pred, smr):
+    assert slot_mismatch_rate(y_true, y_pred) == smr
+
 
 
 @pytest.mark.parametrize("y_true, y_pred, fnr", [
@@ -11,3 +38,14 @@ from eevee.metrics import slot_fnr
 ])
 def test_slot_fnr(y_true, y_pred, fnr):
     assert slot_fnr(y_true, y_pred) == fnr
+
+
+@pytest.mark.parametrize("y_true, y_pred, fpr", [
+    ([None, None, None, None], [None, None, None, None], 0),
+    ([None, None, None, None], [{}, None, None, None], 0.25),
+    ([None, {}, None, None], [None, None, None, None], 0),
+    ([None, None, {}], [None, {}, None], 0.5),
+    ([None, {}, {}, None], [None, None, None, {}], 0.5)
+])
+def test_slot_fpr(y_true, y_pred, fpr):
+    assert slot_fpr(y_true, y_pred) == fpr


### PR DESCRIPTION
have added definitions and tests for

* `slot_capture_rate`
* `slot_retry_rate`
* `slot_mismatch_rate`
* `slot_fpr`

and relevant tests for each. I fear these implementations might not be faithful to your expectations and description from [here](https://github.com/Vernacular-ai/onboarding/blob/master/ml/slot-reporting/slot-evaluation-and-reporting.ipynb), especially `slot_capture_rate`. 

Please show me the way 🙇‍♂️